### PR TITLE
fix bug when parse url start with http://

### DIFF
--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -19,10 +19,12 @@ function fullUrlForHelper(path = '/') {
     if (/^(\/\/|http(s)?:)/.test(path)) return path;
 
     const sitehost = parse(config.url).hostname || config.url;
-    const data = new URL(path, `http://${sitehost}`);
-
-    // Exit if input is an external link or a data url
-    if (data.hostname !== sitehost || data.origin === 'null') return path;
+    let data = null;
+    try {
+      data = new URL(path, `http://${sitehost}`);
+      // Exit if input is an external link or a data url
+      if (data.hostname !== sitehost || data.origin === 'null') return path;
+    } catch {}
 
     path = encodeURL(config.url + `/${path}`.replace(/\/{2,}/g, '/'));
     path = prettyUrls(path, prettyUrlsOptions);


### PR DESCRIPTION
When a markdown document have links which start with "http://", then will get Invalid URL error in `hexo generate` or `hexo server` command, such as:

```
ERROR Process failed: _posts/test.md
TypeError [ERR_INVALID_URL]: Invalid URL: http://
    at onParseError (internal/url.js:257:9)
    at new URL (internal/url.js:333:5)
    at new URL (internal/url.js:330:22)
    at /Users/jason/Documents/blog_store/node_modules/hexo-util/lib/full_url_for.js:22:18
    at Cache.apply (/Users/jason/Documents/blog_store/node_modules/hexo-util/lib/cache.js:27:46)
    at Hexo.fullUrlForHelper (/Users/jason/Documents/blog_store/node_modules/hexo-util/lib/full_url_for.js:18:16)
    at Hexo.module.exports (/Users/jason/Documents/blog_store/node_modules/hexo/lib/plugins/helper/full_url_for.js:5:23)
    at _Document.<anonymous> (/Users/jason/Documents/blog_store/node_modules/hexo/lib/models/post.js:54:25)
    at _Document.permalink (/Users/jason/Documents/blog_store/node_modules/warehouse/lib/types/virtual.js:59:24)
    at _Document.toObject (/Users/jason/Documents/blog_store/node_modules/warehouse/lib/document.js:73:44)
    at _Model._insertOne (/Users/jason/Documents/blog_store/node_modules/warehouse/lib/model.js:157:25)
    at /Users/jason/Documents/blog_store/node_modules/warehouse/lib/model.js:179:63
    at tryCatcher (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/util.js:16:23)
    at /Users/jason/Documents/blog_store/node_modules/bluebird/js/release/using.js:185:26
    at tryCatcher (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/promise.js:729:18)
    at Promise._fulfill (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/promise.js:673:18)
    at PromiseArray._resolve (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/promise_array.js:127:19)
    at PromiseArray._promiseFulfilled (/Users/jason/Documents/blog_store/node_modules/bluebird/js/release/promise_array.js:145:14)
```